### PR TITLE
Invalid add_to_cart_url & actionProductSave hook

### DIFF
--- a/ps_featuredproducts.php
+++ b/ps_featuredproducts.php
@@ -80,6 +80,8 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
             && $this->registerHook('displayOrderConfirmation2')
             && $this->registerHook('displayCrossSellingShoppingCart')
             && $this->registerHook('actionAdminGroupsControllerSaveAfter')
+            && $this->registerHook('actionAuthentication')
+            && $this->registerHook('actionProductSave')
         ;
     }
 
@@ -111,6 +113,16 @@ class Ps_FeaturedProducts extends Module implements WidgetInterface
     }
 
     public function hookActionAdminGroupsControllerSaveAfter($params)
+    {
+        $this->_clearCache('*');
+    }
+    
+    public function hookActionAuthentication($params)
+    {
+        $this->_clearCache('*');
+    }
+
+    public function hookActionProductSave($params)
     {
         $this->_clearCache('*');
     }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | solves two problems with cache (described below)
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Simple code to read ;-)

2 problems:
* add_to_cart_url has invalid token after login to different account.
* in prestashop 1.7.7.0 we need actionProductSave hook to recalculate featured products when something changes. (after changing visibility of product I had no changes in featured products section - I needed to clear cache)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
